### PR TITLE
Restore DeviceActions from JSON Template

### DIFF
--- a/DeviceActionInstruction/DeviceActionInstruction.cs
+++ b/DeviceActionInstruction/DeviceActionInstruction.cs
@@ -23,6 +23,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace DaleGhent.NINA.DeviceActionsCommands {
 
@@ -131,6 +132,7 @@ namespace DaleGhent.NINA.DeviceActionsCommands {
 
         private IList<string> supportedActions = new List<string>();
 
+        [JsonProperty]
         public IList<string> SupportedActions {
             get => supportedActions;
             set {
@@ -254,7 +256,7 @@ namespace DaleGhent.NINA.DeviceActionsCommands {
         }
 
         private IList<string> UpdateSupportedActions() {
-            return deviceType switch {
+            IList<string> actions = deviceType switch {
                 DeviceTypeEnum.CAMERA => cameraMediator.GetInfo().SupportedActions,
                 DeviceTypeEnum.DOME => domeMediator.GetInfo().SupportedActions,
                 DeviceTypeEnum.FILTERWHEEL => filterWheelMediator.GetInfo().SupportedActions,
@@ -268,6 +270,12 @@ namespace DaleGhent.NINA.DeviceActionsCommands {
                 DeviceTypeEnum.WEATHERDATA => weatherDataMediator.GetInfo().SupportedActions,
                 _ => new List<string>(),
             };
+            // If the device is not connected or no actions are available, use the actions loaded from the JSON template
+            if (actions == null || actions.Count == 0) {
+                actions = SupportedActions;
+            }
+
+            return actions ?? new List<string>();
         }
     }
 }


### PR DESCRIPTION
In case we are loading a sequence (i.e. automated on startup), but the equipment is not yet connected, the combobox for deviceaction will be empty and needs to be reselected each time.

This change will save the action names in the sequence and restore them in case they are empty.

Tested with connected and disconnected mount, in both cases the action name was shown.

![image](https://github.com/user-attachments/assets/627e63b9-9dc1-4fb1-ac08-2e030317b43a)
